### PR TITLE
(fixes #56) creation of pipe is now located at history repertory

### DIFF
--- a/front/src/main/javascript/creation/creation.js
+++ b/front/src/main/javascript/creation/creation.js
@@ -64,14 +64,12 @@ Pipes.Creation = {
 $('.create').click(function(){
      var date= new Date(),
      mapping=$(".inputFieldCrea").data("mapping"),
-     today= ('0'+date.getDate()).slice(-2)+'-' +('0'+(date.getMonth()+1)).slice(-2)+'-'+date.getFullYear(),
-     current=location.pathname,
-     pathRepertory = current.substring(0,current.lastIndexOf("/"))+('/'),
+     today= date.getFullYear()+'-'+('0'+(date.getMonth()+1)).slice(-2)+'-'+('0'+date.getDate()).slice(-2)+'_'+('0'+date.getHours()).slice(-2)+'-'+('0'+date.getMinutes()).slice(-2),
      input = $('.inputFieldCrea').val(),
      data = Pipes.Creation.buildJson(input,mapping),
      dataString=JSON.stringify(data);
      $.ajax({
-        url : pathRepertory,
+        url : "http://localhost:4502/etc/sling/pipes/history/"+date.getFullYear()+'/'+('0'+(date.getMonth()+1)).slice(-2),
         type :'post',
         data :{":operation":"import",
                ":contentType":"json",

--- a/front/src/test/javascript/specs/CreationSpec.js
+++ b/front/src/test/javascript/specs/CreationSpec.js
@@ -70,7 +70,6 @@ var mapping = {
   });
 
   it("buildJson should convert a command into corresponding container pipe configuration",function(){
-
     expect(Pipes.Creation.buildJson("$  /content/foo  cq:Page | rm",mapping)).toEqual({
         "jcr:primaryType":"nt:unstructured",
         "sling:resourceType":"slingPipes/container",


### PR DESCRIPTION
Conflicts:

	front/src/test/javascript/specs/CreationSpec.js